### PR TITLE
Fix debug messages + optimize AGED_ALCOHOL map

### DIFF
--- a/src/main/java/com/lumintorious/tfchomestead/client/renderers/ClientEvents.java
+++ b/src/main/java/com/lumintorious/tfchomestead/client/renderers/ClientEvents.java
@@ -65,12 +65,12 @@ public class ClientEvents {
             FluidStack fluidStack = cap.getFluidInTank(0);
             if(!fluidStack.isEmpty()) {
                 event.getToolTip().add(new TranslatableComponent(fluidStack.getTranslationKey()).withStyle(ChatFormatting.GRAY));
-                var fluid = HomesteadFluid.AGED_ALCOHOL.inverse().keySet().stream().filter(f ->
-                    f.getSource() == fluidStack.getFluid()
-                ).findAny();
-                fluid.ifPresent(f -> {
-                    event.getToolTip().add(HomesteadFluid.AGED_ALCOHOL.inverse().get(f).getTooltip());
-                });
+                HomesteadFluid.AGED_ALCOHOL
+                        .entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue().getSource() == fluidStack.getFluid())
+                        .findAny()
+                        .map(entry -> event.getToolTip().add(entry.getKey().getTooltip()));
             }
         });
     }

--- a/src/main/java/com/lumintorious/tfchomestead/common/drinks/HomesteadFluid.java
+++ b/src/main/java/com/lumintorious/tfchomestead/common/drinks/HomesteadFluid.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -44,12 +45,11 @@ public class HomesteadFluid {
     public static Optional<AgedAlcohol> getAlcohol(IFluidHandlerItem handler) {
         FluidStack fluidStack = handler.getFluidInTank(0);
         if(!fluidStack.isEmpty()) {
-            var fluid = HomesteadFluid.AGED_ALCOHOL.inverse().keySet().stream().filter(f -> {
-                System.out.println(f.getSource().getSource());
-                System.out.println(fluidStack.getFluid());
-                return f.getSource().getSource() == fluidStack.getFluid();
-            }).findAny();
-            return fluid.map(f -> HomesteadFluid.AGED_ALCOHOL.inverse().get(f));
+            return HomesteadFluid.AGED_ALCOHOL
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue().getSource().getSource() == fluidStack.getFluid())
+                    .map(Map.Entry::getKey).findAny();
         }
         return Optional.empty();
     }

--- a/src/main/java/com/lumintorious/tfchomestead/common/drinks/HomesteadFluid.java
+++ b/src/main/java/com/lumintorious/tfchomestead/common/drinks/HomesteadFluid.java
@@ -1,14 +1,13 @@
 package com.lumintorious.tfchomestead.common.drinks;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.lumintorious.tfchomestead.TFCHomestead;
 import net.dries007.tfc.common.blocks.TFCBlocks;
-import net.dries007.tfc.common.fluids.*;
+import net.dries007.tfc.common.fluids.FlowingFluidRegistryObject;
+import net.dries007.tfc.common.fluids.FluidType;
+import net.dries007.tfc.common.fluids.MixingFluid;
 import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.registry.RegistrationHelpers;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
@@ -29,13 +28,12 @@ import static net.dries007.tfc.common.fluids.TFCFluids.*;
 public class HomesteadFluid {
     public static final DeferredRegister<Fluid> FLUIDS = DeferredRegister.create(ForgeRegistries.FLUIDS, TFCHomestead.MOD_ID);;
 
-    public static final BiMap<AgedAlcohol, FlowingFluidRegistryObject<MixingFluid>> AGED_ALCOHOL;
+    public static final Map<AgedAlcohol, FlowingFluidRegistryObject<MixingFluid>> AGED_ALCOHOL;
 
     static {
-        var oneWayMap = Helpers.mapOfKeys(AgedAlcohol.class, (fluid) -> register(fluid.getId(), "flowing_" + fluid.getId(), (properties) -> {
+        AGED_ALCOHOL = Helpers.mapOfKeys(AgedAlcohol.class, (fluid) -> register(fluid.getId(), "flowing_" + fluid.getId(), (properties) -> {
             properties.block(TFCBlocks.ALCOHOLS.get(fluid)).bucket(TFCItems.FLUID_BUCKETS.get(FluidType.asType(fluid)));
         }, FluidAttributes.builder(WATER_STILL, WATER_FLOW).translationKey("fluid.tfchomestead." + fluid.getId()).color(fluid.getColor()).overlay(WATER_OVERLAY).sound(SoundEvents.BUCKET_FILL, SoundEvents.BUCKET_EMPTY), MixingFluid.Source::new, MixingFluid.Flowing::new));
-        AGED_ALCOHOL = HashBiMap.create(oneWayMap);
     }
 
     private static <F extends FlowingFluid> FlowingFluidRegistryObject<F> register(String sourceName, String flowingName, Consumer<ForgeFlowingFluid.Properties> builder, FluidAttributes.Builder attributes, Function<ForgeFlowingFluid.Properties, F> sourceFactory, Function<ForgeFlowingFluid.Properties, F> flowingFactory) {


### PR DESCRIPTION
It started as an attempt to fix #5, however when reading code related to that, it seems inefficient so I rewrote that part of the code as well.

## Changes
- Change stream related to `HomesteadFluid.AGED_ALCOHOL` to use an `entryset()` instead of looping twice in an inverse map
  - It is more efficient and doesn't require BiMap at all, meaning less memory usage overall (not by much as the map is small but still it is something)
- Change  `HomesteadFluid.AGED_ALCOHOL` from BiMap to a normal map
- Removed the actual debug prints in the loop and so closes #5 

EDIT: It does not improve performance as there never was looping twice due to usage of BiMap, I believe this is till a better code but I can reduce this PR to only removing the debug prints if needed.