### PR TITLE
Fix GrainPile being sheltered everywhere

### DIFF
--- a/src/main/java/com/lumintorious/tfchomestead/common/block/entity/GrainPileBlockEntity.java
+++ b/src/main/java/com/lumintorious/tfchomestead/common/block/entity/GrainPileBlockEntity.java
@@ -63,7 +63,7 @@ public class GrainPileBlockEntity extends FoodHolderBlockEntity {
 
     public boolean canPreserve() {
         return getLevel() != null && !stack.isEmpty() &&
-            getLevel().getBrightness(LightLayer.SKY, getBlockPos()) < 15;
+            getLevel().getBrightness(LightLayer.SKY, getBlockPos()) < 14;
     }
 
     public boolean fits(ItemStack stack) {


### PR DESCRIPTION
- I suspect it is because the `canPreserve` is called after the block is already placed so the value at the pile can never be 15 because there is pile which lowers it to 14

Closes #3 